### PR TITLE
Don’t fall-through to calling the callback multiple times.

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ module.exports = function(source) {
   // If this is Traceur's runtime library, skip it
   if (this.resourcePath === runtimePath) {
     log('Skipping compilation of runtime file: %s', this.resourcePath);
-    callback(null, source);
+    return callback(null, source);
   }
 
   // Add a Webpack loader for the Traceur runtime library. (Transpiled code
@@ -51,7 +51,7 @@ module.exports = function(source) {
     console.error(chalk.red('ERROR:'), 'Traceur encountered the following errors:');
     console.error('\t' + output.errors.join('\n\t'));
 
-    callback(new Error(chalk.red('ERROR:'), 'Please fix these errors and re-run Webpack.'));
+    return callback(new Error(chalk.red('ERROR:'), 'Please fix these errors and re-run Webpack.'));
   }
 
   callback(null, output.js, output.sourceMap);


### PR DESCRIPTION
Prevents the following Webpack error:

```
Error: callback(): The callback was already called.
    at context.callback
(/Users/you/project/node_modules/webpack/node_modules/webpack-core/lib/NormalModuleMixin.js:141:11)
    at Object.module.exports
(/Users/you/project/node_modules/traceur-loader/index.js:57:3)
    at WEBPACK_CORE_LOADER_EXECUTION
(/Users/you/project/node_modules/webpack/node_modules/webpack-core/lib/NormalModuleMixin.js:153:71)
    at runSyncOrAsync
(/Users/you/project/node_modules/webpack/node_modules/webpack-core/lib/NormalModuleMixin.js:153:93)
    at nextLoader
(/Users/you/project/node_modules/webpack/node_modules/webpack-core/lib/NormalModuleMixin.js:266:3)
    at
/Users/you/project/node_modules/webpack/node_modules/webpack-core/lib/NormalModuleMixin.js:268:15
    at runSyncOrAsync
(/Users/you/project/node_modules/webpack/node_modules/webpack-core/lib/NormalModuleMixin.js:158:12)
    at nextLoader
(/Users/you/project/node_modules/webpack/node_modules/webpack-core/lib/NormalModuleMixin.js:266:3)
    at Storage.finished
(/Users/you/project/node_modules/webpack/node_modules/enhanced-resolve/lib/CachedInputFileSystem.js:38:16)
    at fs.js:271:14
```
