### PR TITLE
Showing file name for errors

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,6 +16,7 @@ var support = require('./support');
 var traceur = require('traceur');
 var runtimePath = require.resolve(require('traceur').RUNTIME_PATH);
 var utils = require('loader-utils');
+var path = require('path');
 
 module.exports = function(source) {
   var output;
@@ -46,8 +47,12 @@ module.exports = function(source) {
 
   // If Traceur encountered any errors, report them and bail out
   if (output.errors.length) {
+    var filename = path.relative(process.cwd(), this.resource)
+    var errors = output.errors.map(function(error) {
+      return error.replace('<unknown file>', '<'+filename+'>')
+    }).join('\n\t');
     console.error(chalk.red('ERROR:'), 'Traceur encountered the following errors:');
-    console.error('\t' + output.errors.join('\n\t'));
+    console.error('\t' + errors);
 
     return callback(new Error(chalk.red('ERROR:'), 'Please fix these errors and re-run Webpack.'));
   }


### PR DESCRIPTION
Updated to show the filename for any errors found during compilation. I couldn't figure out how to get Traceur to report them, so I just replaced the string. 
