### PR TITLE
Fix for windows based development where require.resolve paths needed to convert \ to / using node slash package

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -10,11 +10,12 @@
 'use strict';
 
 var chalk = require('chalk');
+var slash = require('slash');
 var parseOptions = require('./parseOptions');
 var parseQuery = require('./parseQuery');
 var support = require('./support');
 var traceur = require('traceur');
-var runtimePath = require.resolve(require('traceur').RUNTIME_PATH);
+var runtimePath = slash(require.resolve(require('traceur').RUNTIME_PATH));
 var utils = require('loader-utils');
 
 module.exports = function(source) {


### PR DESCRIPTION
On Windows, when using require.resolve, the path is resolved with \ and when traceur was compiling the source it was creating \ in the path names. To get around this, I had to require the node slash package in webpack-traceur-loader/lib/index.js and then use it as to convert the \ to /.
